### PR TITLE
Add HOD reports controller and views

### DIFF
--- a/controllers/HodReportsController.php
+++ b/controllers/HodReportsController.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Generate reports for the HOD within the main application context.
+ */
+
+namespace app\controllers;
+
+use app\components\SmisHelper;
+use app\models\Department;
+use app\models\Faculty;
+use app\models\MarksheetDef;
+use app\models\search\DepartmentCoursesSearch;
+use app\models\search\SubmittedMarksSearch;
+use Exception;
+use Yii;
+use yii\db\Exception as dbException;
+use yii\filters\AccessControl;
+use yii\web\ForbiddenHttpException;
+use yii\web\ServerErrorHttpException;
+
+class HodReportsController extends BaseController
+{
+    /**
+     * Configure controller behaviours.
+     *
+     * @return array
+     */
+    public function behaviors(): array
+    {
+        return [
+            'access' => [
+                'class' => AccessControl::class,
+                'rules' => [
+                    [
+                        'allow' => true,
+                        'roles' => ['@'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @throws ForbiddenHttpException
+     * @throws ServerErrorHttpException
+     */
+    public function init()
+    {
+        parent::init();
+        SmisHelper::allowAccess(['LEC_SMIS_HOD']);
+    }
+
+    /**
+     * Display courses in the HOD's department.
+     *
+     * @throws ServerErrorHttpException
+     */
+    public function actionDepartmentCourses(): string
+    {
+        try {
+            $request = Yii::$app->request;
+            $level = $request->get('level', 'hod');
+            $deptCode = $request->get('deptCode', $this->deptCode);
+            $type = $request->get('type', 'reports');
+
+            if ($level !== 'hod') {
+                throw new Exception('You must give the correct approval level.');
+            }
+
+            if ($deptCode !== $this->deptCode) {
+                throw new Exception('The HOD is not allowed to view courses in another department.');
+            }
+
+            $department = Department::find()
+                ->select(['DEPT_NAME'])
+                ->where(['DEPT_CODE' => $deptCode])
+                ->one();
+            if ($department === null) {
+                throw new Exception('The department could not be found.');
+            }
+
+            $faculty = Faculty::find()
+                ->select(['FACULTY_NAME'])
+                ->where(['FAC_CODE' => $this->facCode])
+                ->one();
+
+            $academicYear = $this->getCurrentAcademicYear();
+
+            $searchModel = new DepartmentCoursesSearch();
+            $departmentCoursesProvider = $searchModel->search(Yii::$app->request->queryParams, [
+                'deptCode' => $deptCode,
+                'academicYear' => $academicYear,
+            ]);
+
+            return $this->render('index', [
+                'title' => 'Courses in the department of ' . strtolower($department->DEPT_NAME),
+                'searchModel' => $searchModel,
+                'departmentCoursesProvider' => $departmentCoursesProvider,
+                'deptCode' => $deptCode,
+                'deptName' => $department->DEPT_NAME,
+                'academicYear' => $academicYear,
+                'level' => $level,
+                'type' => $type,
+                'facName' => $faculty?->FACULTY_NAME,
+            ]);
+        } catch (Exception | dbException $ex) {
+            if (YII_ENV_PROD) {
+                $message = $ex instanceof dbException ? 'This request failed to process.' : $ex->getMessage();
+            } else {
+                $message = $ex->getMessage() . ' File: ' . $ex->getFile() . ' Line: ' . $ex->getLine();
+            }
+            throw new ServerErrorHttpException($message, 500);
+        }
+    }
+
+    /**
+     * List the submitted marks for a marksheet.
+     *
+     * @throws ServerErrorHttpException
+     */
+    public function actionSubmittedMarks(): string
+    {
+        try {
+            $request = Yii::$app->request;
+            $marksheetId = $request->get('marksheetId');
+            $level = $request->get('level');
+            $deptCode = $request->get('deptCode');
+            $type = $request->get('type');
+
+            $mkModel = MarksheetDef::findOne($marksheetId);
+            if ($mkModel === null) {
+                throw new Exception('The requested marksheet was not found.');
+            }
+
+            $courseCode = $mkModel->course->COURSE_CODE;
+            $courseName = $mkModel->course->COURSE_NAME;
+
+            $searchModel = new SubmittedMarksSearch();
+            $submittedMarkskProvider = $searchModel->search(Yii::$app->request->queryParams, [
+                'deptCode' => $this->deptCode,
+                'facCode' => $this->facCode,
+                'marksheetId' => $marksheetId,
+                'level' => 'hod',
+            ]);
+
+            $department = Department::find()->select(['DEPT_NAME'])
+                ->where(['DEPT_CODE' => $deptCode])->one();
+            $deptName = $department?->DEPT_NAME;
+
+            $faculty = Faculty::find()->select(['FACULTY_NAME'])->where(['FAC_CODE' => $this->facCode])
+                ->one();
+
+            return $this->render('submittedMarks', [
+                'title' => 'Submitted marks for marksheet ' . $marksheetId,
+                'searchModel' => $searchModel,
+                'submittedMarkskProvider' => $submittedMarkskProvider,
+                'marksheetId' => $marksheetId,
+                'courseCode' => $courseCode,
+                'courseName' => $courseName,
+                'facName' => $faculty?->FACULTY_NAME,
+                'academicYear' => $this->getCurrentAcademicYear(),
+                'level' => $level,
+                'deptCode' => $deptCode,
+                'deptName' => $deptName,
+                'type' => $type,
+            ]);
+        } catch (Exception | dbException $ex) {
+            if (YII_ENV_PROD) {
+                $message = $ex instanceof dbException ? 'This request failed to process.' : $ex->getMessage();
+            } else {
+                $message = $ex->getMessage() . ' File: ' . $ex->getFile() . ' Line: ' . $ex->getLine();
+            }
+            throw new ServerErrorHttpException($message, 500);
+        }
+    }
+}

--- a/views/hod-reports/index.php
+++ b/views/hod-reports/index.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @var $this yii\web\View
+ * @var $model app\models\MarksheetDef
+ * @var $searchModel app\models\search\DepartmentCoursesSearch
+ * @var $departmentCoursesProvider yii\data\ActiveDataProvider
+ * @var $title string
+ * @var $deptCode string
+ * @var $deptName string
+ * @var $academicYear string
+ * @var $level string
+ * @var $type string
+ * @var $facName string
+ */
+
+use yii\helpers\Html;
+use yii\helpers\Url;
+use kartik\grid\GridView;
+
+$this->title = $title;
+
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="returned-script-courses">
+    <h3><?= $facName; ?></h3>
+    <?php
+        $gridColumns = [
+            ['class' => 'kartik\\grid\\SerialColumn'],
+            [
+                'attribute' => 'course.COURSE_CODE',
+                'label' => 'COURSE CODE',
+            ],
+            [
+                'attribute' => 'course.COURSE_NAME',
+                'label' => 'COURSE NAME'
+            ],
+            [
+                'attribute' => 'semester.degreeProgramme.DEGREE_NAME',
+                'label' => 'DEGREE NAME',
+                'width' => '310px',
+                'group' => true,
+                'groupedRow' => true,
+                'groupOddCssClass' => 'kv-grouped-row',
+                'groupEvenCssClass' => 'kv-grouped-row',
+            ],
+            [
+                'class' => 'kartik\\grid\\ActionColumn',
+                'template' => '{submitted-marks-report}',
+                'contentOptions' => ['style' => 'white-space:nowrap;', 'class' => 'kartik-sheet-style kv-align-middle'],
+                'buttons' => [
+                    'submitted-marks-report' => function ($url, $model) use ($level, $type) {
+                        return Html::a('<i class="fas fa-file"></i> submitted marks report',
+                            Url::to([
+                                '/hod-reports/submitted-marks',
+                                'marksheetId' => $model['MRKSHEET_ID'],
+                                'level' => $level,
+                                'type' => $type,
+                                'deptCode' => $model['course']['dept']['DEPT_CODE']
+                            ]),
+                            [
+                                'title' => 'Submitted marks report',
+                                'class' => 'btn btn-xs btn-spacer'
+                            ]
+                        );
+                    }
+                ]
+            ]
+        ];
+
+        $gridId = 'hod-reports-department-courses-grid';
+        $title = 'COURSES IN THE DEPARTMENT OF ' . $deptName . ' | ACADEMIC YEAR ' . $academicYear;
+
+        echo GridView::widget([
+            'id' => $gridId,
+            'dataProvider' => $departmentCoursesProvider,
+            'filterModel' => $searchModel,
+            'columns' => $gridColumns,
+            'headerRowOptions' => ['class' => 'kartik-sheet-style'],
+            'filterRowOptions' => ['class' => 'kartik-sheet-style'],
+            'pjax' => true,
+            'pjaxSettings' => [
+                'options' => [
+                    'id' => $gridId . '-pjax'
+                ]
+            ],
+            'toolbar' => [
+                '{toggleData}'
+            ],
+            'panel' => [
+                'type' => GridView::TYPE_PRIMARY,
+                'heading' => '<h3 class="panel-title">' . $title . '</h3>',
+            ],
+            'toggleDataContainer' => ['class' => 'btn-group mr-2'],
+            'toggleDataOptions' => ['minCount' => 20],
+            'itemLabelSingle' => 'course',
+            'itemLabelPlural' => 'courses',
+        ]);
+    ?>
+</div>

--- a/views/hod-reports/submittedMarks.php
+++ b/views/hod-reports/submittedMarks.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * @var $this yii\web\View
+ * @var $title string
+ * @var $model app\models\StudentCoursework
+ * @var $searchModel app\models\search\SubmittedMarksSearch
+ * @var $submittedMarkskProvider yii\data\ActiveDataProvider
+ * @var $marksheetId string
+ * @var $courseCode string
+ * @var $courseName string
+ * @var $level string
+ * @var $deptCode string
+ * @var $deptName string
+ * @var $type string
+ * @var $facName string
+ * @var $academicYear string
+ */
+
+use app\components\GridExport;
+use app\models\EmpVerifyView;
+use kartik\grid\GridView;
+
+$this->title = $title;
+
+$this->params['breadcrumbs'][] = [
+    'label' => 'courses in the department of ' . $deptName,
+    'url' => [
+        '/hod-reports/department-courses',
+        'level' => $level,
+        'deptCode' => $deptCode,
+        'type' => $type
+    ]
+];
+
+$this->params['breadcrumbs'][] = $this->title;
+?>
+
+<div class="hod-reports-submitted-marks">
+    <h3><?= $facName; ?></h3>
+    <?php
+        $gridId = 'hod-reports-submitted-marks-grid';
+        $title = $courseName . ' (' . $courseCode . ') EXAM MARKS';
+        $fileName = $courseCode . '_submitted_exam_marks';
+        $contentBefore = '';
+        $contentAfter = '';
+        $centerContent = $courseCode . ' SUBMITTED EXAM MARKS | ACADEMIC YEAR ' . $academicYear;
+        $registrationNoColumn = [
+            'attribute' => 'REGISTRATION_NUMBER',
+            'label' => 'REGISTRATION NUMBER',
+            'hAlign' => 'left',
+        ];
+        $marksColumn = [
+            'attribute' => 'MARK',
+            'label' => 'MARKS',
+            'hAlign' => 'left'
+        ];
+        $userColumn = [
+            'attribute' => 'USER_ID',
+            'label' => 'ENTERED BY',
+            'hAlign' => 'left',
+            'value' => function ($model) {
+                $lecturer = EmpVerifyView::find()
+                    ->select(['PAYROLL_NO', 'SURNAME', 'OTHER_NAMES', 'EMP_TITLE'])
+                    ->where(['PAYROLL_NO' => $model['USER_ID']])
+                    ->one();
+                return $lecturer->EMP_TITLE . ' ' . $lecturer->SURNAME . ' ' . $lecturer->OTHER_NAMES;
+            }
+        ];
+        $dateColumn = [
+            'attribute' => 'DATE_ENTERED',
+            'label' => 'DATE ENTERED',
+            'hAlign' => 'left',
+            'width' => '20%',
+            'format' => 'raw',
+            'contentOptions' => ['class' => 'kartik-sheet-style kv-align-middle'],
+            'filterType' => GridView::FILTER_DATE,
+            'filterWidgetOptions' => [
+                'options' => ['id' => 'exam-marks-date-entered'],
+                'pluginOptions' => ['autoclose' => true, 'allowClear' => true, 'format' => 'dd-M-yyyy'],
+            ],
+            'filterInputOptions' => ['placeholder' => 'Date Entered'],
+            'value' => function ($model) {
+                return $model['DATE_ENTERED'];
+            }
+        ];
+        $remarksColumn = [
+            'label' => 'REMARKS',
+            'value' => function ($model) {
+                return is_null($model['REMARKS']) ? '' : $model['REMARKS'];
+            },
+            'width' => '20%',
+            'hAlign' => 'left'
+        ];
+
+        echo GridView::widget([
+            'id' => $gridId,
+            'dataProvider' => $submittedMarkskProvider,
+            'filterModel' => $searchModel,
+            'columns' => [
+                ['class' => 'kartik\\grid\\SerialColumn'],
+                $registrationNoColumn,
+                $marksColumn,
+                $remarksColumn,
+                $userColumn,
+                $dateColumn
+            ],
+            'headerRowOptions' => ['class' => 'kartik-sheet-style'],
+            'filterRowOptions' => ['class' => 'kartik-sheet-style'],
+            'pjax' => true,
+            'toolbar' => [
+                '{export}',
+                '{toggleData}'
+            ],
+            'toggleDataContainer' => ['class' => 'btn-group mr-2'],
+            'export' => [
+                'fontAwesome' => false,
+            ],
+            'panel' => [
+                'type' => GridView::TYPE_PRIMARY,
+                'heading' => '<h3 class="panel-title">' . $title . '</h3>',
+            ],
+            'persistResize' => false,
+            'toggleDataOptions' => ['minCount' => 20],
+            'exportConfig' => [
+                GridView::PDF => GridExport::exportPdf([
+                    'filename' => $fileName,
+                    'title' => $title,
+                    'subject' => 'submitted marks',
+                    'keywords' => 'submitted marks',
+                    'contentBefore' => $contentBefore,
+                    'contentAfter' => $contentAfter,
+                    'centerContent' => $centerContent
+                ])
+            ],
+            'itemLabelSingle' => 'mark',
+            'itemLabelPlural' => 'marks',
+        ]);
+    ?>
+</div>


### PR DESCRIPTION
## Summary
- add a top-level HodReportsController mirroring the module behaviour
- add hod-reports index and submitted marks views for the main app
- ensure the controller enforces HOD access and prepares the expected data providers

## Testing
- `php yii route/list | grep hod-reports` *(fails: vendor/ dependencies not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce27e08cf08329aabc3d93b190c941