### PR TITLE
Refine class performance export layout

### DIFF
--- a/controllers/SharedReportsController.php
+++ b/controllers/SharedReportsController.php
@@ -591,34 +591,37 @@ class SharedReportsController extends BaseController
     private function classPerformanceCss(): string
     {
         return <<<CSS
-.class-performance-pdf { font-size: 9.5pt; color: #1f2933; line-height: 1.4; }
+.class-performance-pdf { font-size: 9.3pt; color: #1f2933; line-height: 1.35; }
 .class-performance-pdf * { box-sizing: border-box; }
 .report-title { margin-bottom: 12px; }
 .report-title h1 { font-size: 16pt; margin: 0; color: #0b3d91; text-transform: uppercase; letter-spacing: 0.6px; }
 .report-title .report-subtitle { margin: 4px 0 0; font-size: 10pt; color: #4a5568; }
-.report-title .report-meta { margin: 6px 0 0; font-size: 8.5pt; color: #6c757d; }
+.report-title .report-meta { margin: 4px 0 0; font-size: 8.3pt; color: #6c757d; }
 .summary-card { border: 1px solid #d9dee7; border-radius: 8px; overflow: hidden; margin-bottom: 14px; background-color: #ffffff; page-break-inside: avoid; }
-.summary-card__header { background-color: #0b3d91; color: #ffffff; padding: 8px 12px; font-size: 9pt; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; }
-.summary-card__body { padding: 12px; }
+.summary-card__header { background-color: #0b3d91; color: #ffffff; padding: 7px 12px; font-size: 8.7pt; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; }
+.summary-card__body { padding: 10px 12px; }
 .summary-grid { width: 100%; border-collapse: collapse; }
-.summary-grid td { width: 33.33%; padding: 6px 10px; vertical-align: top; }
+.summary-grid td { width: 33.33%; padding: 4px 8px; vertical-align: top; }
 .summary-grid__label { display: block; font-size: 8.2pt; text-transform: uppercase; color: #6c757d; letter-spacing: 0.3px; margin-bottom: 2px; }
 .summary-grid__value { display: block; font-weight: 600; color: #1f2933; font-size: 9.5pt; }
-.dashboard-grid { width: 100%; border-collapse: separate; border-spacing: 10px; margin: 0 0 14px; }
-.dashboard-grid .dashboard-cell { vertical-align: top; }
-.dashboard-cell--wide { width: 40%; }
-.dashboard-cell--chart { width: 32%; }
-.dashboard-cell--compact { width: 28%; }
-.dashboard-cell--notes { width: 28%; }
+.layout-grid { width: 100%; border-collapse: separate; border-spacing: 12px 10px; margin: 0 0 12px; }
+.layout-grid__col--wide { width: 60%; }
+.layout-grid__col--narrow { width: 40%; }
+.layout-grid__cell { vertical-align: top; padding: 0; }
+.layout-grid__cell--stack { padding: 0; }
+.stack-grid { width: 100%; border-collapse: separate; border-spacing: 10px; }
+.stack-grid__cell { padding: 0; vertical-align: top; }
 .panel-card { border: 1px solid #d9dee7; border-radius: 8px; overflow: hidden; background-color: #ffffff; page-break-inside: avoid; }
-.panel-card .panel-header { background-color: #f1f4fb; color: #0b3d91; padding: 8px 12px; font-size: 8.5pt; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
-.panel-card .panel-body { padding: 12px; }
+.panel-card .panel-header { background-color: #f1f4fb; color: #0b3d91; padding: 7px 11px; font-size: 8.3pt; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
+.panel-card .panel-body { padding: 10px 12px; }
+.panel-card.panel-card--compact .panel-body { padding: 9px 10px; }
+.panel-card.panel-card--notes .panel-body { padding: 9px 10px; }
 .data-table { width: 100%; border-collapse: collapse; }
-.data-table th, .data-table td { border: 1px solid #d9dee7; padding: 6px 8px; font-size: 8.5pt; }
+.data-table th, .data-table td { border: 1px solid #d9dee7; padding: 5px 7px; font-size: 8.3pt; }
 .data-table th { background-color: #f9fafe; text-transform: uppercase; color: #6c757d; font-weight: 600; }
 .data-table .text-end { text-align: right; }
 .totals-row td { background-color: #f1f4fb; font-weight: 600; }
-.panel-intro { font-size: 8.3pt; color: #6c757d; margin-bottom: 8px; }
+.panel-intro { font-size: 8.1pt; color: #6c757d; margin-bottom: 6px; }
 .chart-container { margin: 0 auto; text-align: center; }
 .chart-svg { width: 100%; height: auto; max-width: 340px; }
 .chart-axis { stroke: #93a3b8; stroke-width: 1; }
@@ -629,14 +632,14 @@ class SharedReportsController extends BaseController
 .chart-value { font-size: 8pt; fill: #0b3d91; font-weight: 700; }
 .chart-tick { font-size: 7.5pt; fill: #6c757d; }
 .info-table { width: 100%; border-collapse: collapse; }
-.info-table th { text-transform: uppercase; font-size: 8.3pt; color: #6c757d; padding: 4px 0; text-align: left; }
-.info-table td { font-size: 9.5pt; color: #1f2933; font-weight: 600; padding: 4px 0; text-align: right; }
+.info-table th { text-transform: uppercase; font-size: 8.1pt; color: #6c757d; padding: 3px 0; text-align: left; }
+.info-table td { font-size: 9.3pt; color: #1f2933; font-weight: 600; padding: 3px 0; text-align: right; }
 .notes-text { font-size: 8.5pt; color: #4a5568; margin: 0; line-height: 1.45; }
 .signatory-card .panel-body { padding: 0; }
 .signatory-table { width: 100%; border-collapse: collapse; }
-.signatory-table td { border: 1px solid #d9dee7; padding: 12px; vertical-align: top; width: 33.33%; }
-.signatory-label { text-transform: uppercase; font-size: 8.5pt; color: #0b3d91; font-weight: 600; letter-spacing: 0.4px; margin-bottom: 12px; }
-.signature-line { border-bottom: 1px solid #8d99ae; margin: 18px 0 12px; height: 16px; }
+.signatory-table td { border: 1px solid #d9dee7; padding: 10px; vertical-align: top; width: 33.33%; }
+.signatory-label { text-transform: uppercase; font-size: 8.5pt; color: #0b3d91; font-weight: 600; letter-spacing: 0.4px; margin-bottom: 10px; }
+.signature-line { border-bottom: 1px solid #8d99ae; margin: 14px 0 10px; height: 14px; }
 .signatory-meta { font-size: 8.3pt; color: #6c757d; }
 CSS;
     }

--- a/views/shared-reports/_classPerformancePdf.php
+++ b/views/shared-reports/_classPerformancePdf.php
@@ -37,9 +37,9 @@ $gradeCounts = array_map(static function ($row) {
 
 $gradeBarCount = max(count($gradeLabels), 1);
 $gradeChartHeight = 170;
-$gradeBarWidth = 28;
-$gradeBarSpacing = 16;
-$gradeAxisLeft = 42;
+$gradeBarWidth = 24;
+$gradeBarSpacing = 12;
+$gradeAxisLeft = 38;
 $gradeAxisBottom = $gradeChartHeight + 20;
 $gradeSvgHeight = $gradeChartHeight + 60;
 $gradeSvgWidth = (int)($gradeAxisLeft + ($gradeBarCount * ($gradeBarWidth + $gradeBarSpacing)) + 16);
@@ -54,9 +54,9 @@ $averageValues = [
     (float)($averages['final'] ?? 0),
 ];
 $averageMaxValue = max(array_merge([100.0], $averageValues, [1]));
-$averageBarWidth = 38;
-$averageBarSpacing = 28;
-$averageAxisLeft = 48;
+$averageBarWidth = 32;
+$averageBarSpacing = 22;
+$averageAxisLeft = 44;
 $averageAxisBottom = $averageChartHeight + 20;
 $averageSvgHeight = $averageChartHeight + 60;
 $averageSvgWidth = (int)($averageAxisLeft + (count($averageLabels) * ($averageBarWidth + $averageBarSpacing)) + 24);
@@ -97,9 +97,14 @@ $summaryChunks = array_chunk($reportSummary, 3, true);
         </div>
     </div>
 
-    <table class="dashboard-grid">
+    <table class="layout-grid">
+        <colgroup>
+            <col class="layout-grid__col layout-grid__col--wide" />
+            <col class="layout-grid__col layout-grid__col--narrow" />
+        </colgroup>
+        <tbody>
         <tr>
-            <td class="dashboard-cell dashboard-cell--wide">
+            <td class="layout-grid__cell">
                 <div class="panel-card">
                     <div class="panel-header">Grade distribution</div>
                     <div class="panel-body">
@@ -129,71 +134,78 @@ $summaryChunks = array_chunk($reportSummary, 3, true);
                     </div>
                 </div>
             </td>
-            <td class="dashboard-cell dashboard-cell--chart">
-                <div class="panel-card">
-                    <div class="panel-header">Grade distribution chart</div>
-                    <div class="panel-body">
-                        <p class="panel-intro">Visual overview of grade performance.</p>
-                        <div class="chart-container">
-                            <svg class="chart-svg" width="<?= $gradeSvgWidth; ?>" height="<?= $gradeSvgHeight; ?>" viewBox="0 0 <?= $gradeSvgWidth; ?> <?= $gradeSvgHeight; ?>">
-                                <line x1="<?= $gradeAxisLeft; ?>" y1="<?= $gradeAxisBottom; ?>" x2="<?= $gradeSvgWidth - 12; ?>" y2="<?= $gradeAxisBottom; ?>" class="chart-axis" />
-                                <line x1="<?= $gradeAxisLeft; ?>" y1="<?= $gradeAxisBottom; ?>" x2="<?= $gradeAxisLeft; ?>" y2="<?= $gradeAxisBottom - $gradeChartHeight; ?>" class="chart-axis" />
+            <td class="layout-grid__cell layout-grid__cell--stack">
+                <table class="stack-grid">
+                    <tbody>
+                    <tr>
+                        <td class="stack-grid__cell">
+                            <div class="panel-card">
+                                <div class="panel-header">Grade distribution chart</div>
+                                <div class="panel-body">
+                                    <p class="panel-intro">Visual overview of grade performance.</p>
+                                    <div class="chart-container">
+                                        <svg class="chart-svg" width="<?= $gradeSvgWidth; ?>" height="<?= $gradeSvgHeight; ?>" viewBox="0 0 <?= $gradeSvgWidth; ?> <?= $gradeSvgHeight; ?>">
+                                            <line x1="<?= $gradeAxisLeft; ?>" y1="<?= $gradeAxisBottom; ?>" x2="<?= $gradeSvgWidth - 12; ?>" y2="<?= $gradeAxisBottom; ?>" class="chart-axis" />
+                                            <line x1="<?= $gradeAxisLeft; ?>" y1="<?= $gradeAxisBottom; ?>" x2="<?= $gradeAxisLeft; ?>" y2="<?= $gradeAxisBottom - $gradeChartHeight; ?>" class="chart-axis" />
 
-                                <?php for ($tick = 1; $tick <= $gradeTickSteps; $tick++): ?>
-                                    <?php
-                                    $ratio = $tick / $gradeTickSteps;
-                                    $tickValue = $gradeMaxCount * $ratio;
-                                    $tickY = $gradeAxisBottom - ($gradeChartHeight * $ratio);
-                                    ?>
-                                    <line x1="<?= $gradeAxisLeft; ?>" y1="<?= $tickY; ?>" x2="<?= $gradeSvgWidth - 12; ?>" y2="<?= $tickY; ?>" class="chart-grid" />
-                                    <text x="<?= $gradeAxisLeft - 8; ?>" y="<?= $tickY + 4; ?>" text-anchor="end" class="chart-tick"><?= Html::encode(number_format($tickValue)); ?></text>
-                                <?php endfor; ?>
+                                            <?php for ($tick = 1; $tick <= $gradeTickSteps; $tick++): ?>
+                                                <?php
+                                                $ratio = $tick / $gradeTickSteps;
+                                                $tickValue = $gradeMaxCount * $ratio;
+                                                $tickY = $gradeAxisBottom - ($gradeChartHeight * $ratio);
+                                                ?>
+                                                <line x1="<?= $gradeAxisLeft; ?>" y1="<?= $tickY; ?>" x2="<?= $gradeSvgWidth - 12; ?>" y2="<?= $tickY; ?>" class="chart-grid" />
+                                                <text x="<?= $gradeAxisLeft - 8; ?>" y="<?= $tickY + 4; ?>" text-anchor="end" class="chart-tick"><?= Html::encode(number_format($tickValue)); ?></text>
+                                            <?php endfor; ?>
 
-                                <?php foreach ($gradeCounts as $index => $count): ?>
-                                    <?php
-                                    $label = $gradeLabels[$index] ?? '';
-                                    $barHeight = $gradeMaxCount > 0 ? ($count / $gradeMaxCount) * $gradeChartHeight : 0;
-                                    $barX = $gradeAxisLeft + ($index * ($gradeBarWidth + $gradeBarSpacing)) + ($gradeBarSpacing / 2);
-                                    $barY = $gradeAxisBottom - $barHeight;
-                                    $valueY = $barHeight > 0 ? $barY - 6 : $gradeAxisBottom - 6;
-                                    ?>
-                                    <rect x="<?= $barX; ?>" y="<?= $barY; ?>" width="<?= $gradeBarWidth; ?>" height="<?= $barHeight; ?>" class="chart-bar" />
-                                    <text x="<?= $barX + ($gradeBarWidth / 2); ?>" y="<?= $valueY; ?>" text-anchor="middle" class="chart-value"><?= Html::encode(number_format($count)); ?></text>
-                                    <text x="<?= $barX + ($gradeBarWidth / 2); ?>" y="<?= $gradeAxisBottom + 18; ?>" text-anchor="middle" class="chart-label"><?= Html::encode($label); ?></text>
-                                <?php endforeach; ?>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-            </td>
-            <td class="dashboard-cell dashboard-cell--compact">
-                <div class="panel-card">
-                    <div class="panel-header">Key figures</div>
-                    <div class="panel-body">
-                        <p class="panel-intro">Quick reference metrics for review.</p>
-                        <table class="info-table">
-                            <tr>
-                                <th>Highest grade</th>
-                                <td><?= Html::encode($highestGrade); ?></td>
-                            </tr>
-                            <tr>
-                                <th>Lowest grade</th>
-                                <td><?= Html::encode($lowestGrade); ?></td>
-                            </tr>
-                            <tr>
-                                <th>Report date</th>
-                                <td><?= Html::encode($date); ?></td>
-                            </tr>
-                        </table>
-                    </div>
-                </div>
+                                            <?php foreach ($gradeCounts as $index => $count): ?>
+                                                <?php
+                                                $label = $gradeLabels[$index] ?? '';
+                                                $barHeight = $gradeMaxCount > 0 ? ($count / $gradeMaxCount) * $gradeChartHeight : 0;
+                                                $barX = $gradeAxisLeft + ($index * ($gradeBarWidth + $gradeBarSpacing)) + ($gradeBarSpacing / 2);
+                                                $barY = $gradeAxisBottom - $barHeight;
+                                                $valueY = $barHeight > 0 ? $barY - 6 : $gradeAxisBottom - 6;
+                                                ?>
+                                                <rect x="<?= $barX; ?>" y="<?= $barY; ?>" width="<?= $gradeBarWidth; ?>" height="<?= $barHeight; ?>" class="chart-bar" />
+                                                <text x="<?= $barX + ($gradeBarWidth / 2); ?>" y="<?= $valueY; ?>" text-anchor="middle" class="chart-value"><?= Html::encode(number_format($count)); ?></text>
+                                                <text x="<?= $barX + ($gradeBarWidth / 2); ?>" y="<?= $gradeAxisBottom + 18; ?>" text-anchor="middle" class="chart-label"><?= Html::encode($label); ?></text>
+                                            <?php endforeach; ?>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="stack-grid__cell">
+                            <div class="panel-card panel-card--compact">
+                                <div class="panel-header">Key figures</div>
+                                <div class="panel-body">
+                                    <p class="panel-intro">Quick reference metrics for review.</p>
+                                    <table class="info-table">
+                                        <tr>
+                                            <th>Highest grade</th>
+                                            <td><?= Html::encode($highestGrade); ?></td>
+                                        </tr>
+                                        <tr>
+                                            <th>Lowest grade</th>
+                                            <td><?= Html::encode($lowestGrade); ?></td>
+                                        </tr>
+                                        <tr>
+                                            <th>Report date</th>
+                                            <td><?= Html::encode($date); ?></td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
             </td>
         </tr>
-    </table>
-
-    <table class="dashboard-grid">
         <tr>
-            <td class="dashboard-cell dashboard-cell--chart">
+            <td class="layout-grid__cell">
                 <div class="panel-card">
                     <div class="panel-header">Average scores chart</div>
                     <div class="panel-body">
@@ -230,39 +242,50 @@ $summaryChunks = array_chunk($reportSummary, 3, true);
                     </div>
                 </div>
             </td>
-            <td class="dashboard-cell dashboard-cell--compact">
-                <div class="panel-card">
-                    <div class="panel-header">Average scores summary</div>
-                    <div class="panel-body">
-                        <table class="info-table">
-                            <tr>
-                                <th>Coursework</th>
-                                <td><?= Html::encode(number_format((float)$averages['coursework'], 2)); ?></td>
-                            </tr>
-                            <tr>
-                                <th>Exam</th>
-                                <td><?= Html::encode(number_format((float)$averages['exam'], 2)); ?></td>
-                            </tr>
-                            <tr>
-                                <th>Final score</th>
-                                <td><?= Html::encode(number_format((float)$averages['final'], 2)); ?></td>
-                            </tr>
-                        </table>
-                    </div>
-                </div>
-            </td>
-            <td class="dashboard-cell dashboard-cell--notes">
-                <div class="panel-card">
-                    <div class="panel-header">Notes</div>
-                    <div class="panel-body">
-                        <p class="notes-text">
-                            Use this report to highlight key trends and prepare quick talking points before meetings or when
-                            exporting the PDF for departmental reviews.
-                        </p>
-                    </div>
-                </div>
+            <td class="layout-grid__cell layout-grid__cell--stack">
+                <table class="stack-grid">
+                    <tbody>
+                    <tr>
+                        <td class="stack-grid__cell">
+                            <div class="panel-card panel-card--compact">
+                                <div class="panel-header">Average scores summary</div>
+                                <div class="panel-body">
+                                    <table class="info-table">
+                                        <tr>
+                                            <th>Coursework</th>
+                                            <td><?= Html::encode(number_format((float)$averages['coursework'], 2)); ?></td>
+                                        </tr>
+                                        <tr>
+                                            <th>Exam</th>
+                                            <td><?= Html::encode(number_format((float)$averages['exam'], 2)); ?></td>
+                                        </tr>
+                                        <tr>
+                                            <th>Final score</th>
+                                            <td><?= Html::encode(number_format((float)$averages['final'], 2)); ?></td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="stack-grid__cell">
+                            <div class="panel-card panel-card--notes">
+                                <div class="panel-header">Notes</div>
+                                <div class="panel-body">
+                                    <p class="notes-text">
+                                        Use this report to highlight key trends and prepare quick talking points before meetings or when
+                                        exporting the PDF for departmental reviews.
+                                    </p>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
             </td>
         </tr>
+        </tbody>
     </table>
 
     <div class="panel-card signatory-card">


### PR DESCRIPTION
## Summary
- reorganize the class performance PDF partial into a two-column grid with stacked metric panels to prevent broken layouts in the export
- tighten chart dimensions, spacing, and typography styles so the exported report renders in a more compact, readable format

## Testing
- php -l controllers/SharedReportsController.php
- php -l views/shared-reports/_classPerformancePdf.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e5ff57c8832999c971cbb075ffb5